### PR TITLE
Use git:// instead of ssh:// protocol for repo

### DIFF
--- a/hoauth.cabal
+++ b/hoauth.cabal
@@ -42,4 +42,4 @@ library
 
 source-repository head
   type:     git
-  location: git@github.com:dsouza/hoauth.git
+  location: git://github.com/dsouza/hoauth.git


### PR DESCRIPTION
A world-readable repository URI is easier for copy/paste.
