### PR TITLE
Adding multipart/form-data upload support...

### DIFF
--- a/src/main/haskell/Network/OAuth/Consumer.hs
+++ b/src/main/haskell/Network/OAuth/Consumer.hs
@@ -103,7 +103,7 @@ import qualified Codec.Crypto.RSA as R
 
 -- | A request that is ready to be performed, i.e., that contains authorization headers.
 newtype OAuthRequest = OAuthRequest { unpackRq :: Request }
-                     deriving (Show,Eq)
+                     deriving (Show)
 
 -- | Random string that is unique amongst requests. Refer to <http://oauth.net/core/1.0/#nonce> for more information.
 newtype Nonce = Nonce { unNonce :: String }
@@ -203,9 +203,13 @@ signature m token req = case m
                                             ]
 
         params = if (ifindWithDefault ("content-type","") (reqHeaders req) == "application/x-www-form-urlencoded")
+
+                 -- e.g., in the case of most Twitter API calls
                  then (qString req) `unionAll` (parseQString . map (chr.fromIntegral) 
                                                              . B.unpack 
                                                              . reqPayload $ req)
+
+                 -- e.g., in the case of a "multipart/form-data" image upload, however, the payload isn't signed
                  else qString req
 
 -- | Returns true if the token is able to perform 2-legged oauth requests.

--- a/src/main/haskell/Network/OAuth/Http/CurlHttpClient.hs
+++ b/src/main/haskell/Network/OAuth/Http/CurlHttpClient.hs
@@ -61,18 +61,31 @@ instance HttpClient CurlClient where
           curlMethod = case (method req)
                        of GET   -> [ CurlHttpGet True ]
                           HEAD  -> [ CurlNoBody True,CurlCustomRequest "HEAD" ]
-                          other -> if (B.null.reqPayload $ req)
+                          other -> if ((B.null . reqPayload $ req) && 0 == length (reqPayloadMult req))
                                    then [ CurlHttpGet True,CurlCustomRequest (show other) ]
                                    else [ CurlPost True,CurlCustomRequest (show other) ]
                                         
-          curlPostData = if (B.null.reqPayload $ req)
-                         then []
-                         else [ CurlPostFields [map (chr.fromIntegral).B.unpack.reqPayload $ req] ]
-                              
+          curlPostData =
+             if B.null . reqPayload $ req
+             then
+                case reqPayloadMult req
+                of []    -> []                   -- i.e., no payload at all
+
+                   parts -> [CurlHttpPost parts] -- i.e., "multipart/form-data"
+                                                 -- content with a boundary and MIME stuff
+                                                 -- see libcurl for HttpPost, Content
+             else
+                case reqPayloadMult req
+                of []    -> let tostr = map (chr.fromIntegral).B.unpack
+                                field = reqPayload req
+                            in [CurlPostFields [tostr field]] -- i.e., "application/x-www-form-urlencoded"
+                                                              -- strings with field sep '&'
+                                                              -- although we're only giving libcurl a single field
+
+                   parts -> error "with both CurlPostFields and CurlHttpPost, I'm not sure what libcurl would do..."
+
           curlHeaders = let headers = (map (\(k,v) -> k++": "++v).toList.reqHeaders $ req)
-                        in [ CurlHttpHeaders $ ("Content-Length: " ++ (show.B.length.reqPayload $ req))
-                                               : headers
-                           ]
+                        in [CurlHttpHeaders headers]
 
           opts = [ CurlURL (showURL req)
                  , CurlHttpVersion httpVersion

--- a/src/main/haskell/Network/OAuth/Http/Request.hs
+++ b/src/main/haskell/Network/OAuth/Http/Request.hs
@@ -58,6 +58,7 @@ module Network.OAuth.Http.Request
        ) where
 
 import Control.Monad.State
+import Network.Curl.Post (HttpPost)
 import Network.OAuth.Http.PercentEncoding
 import Network.OAuth.Http.Util
 import Data.List (intercalate,isPrefixOf)
@@ -93,9 +94,10 @@ data Request = ReqHttp { version    :: Version      -- ^ Protocol version
                        , reqHeaders :: FieldList    -- ^ Request headers
                        , pathComps  :: [String]     -- ^ The path split into components 
                        , qString    :: FieldList    -- ^ The query string, usually set for GET requests
-                       , reqPayload :: B.ByteString -- ^ The message body
+                       , reqPayload :: B.ByteString -- ^ The message body (the first/only string part)
+                       , reqPayloadMult :: [HttpPost] -- ^ The message body (in HttpPost parts, see libcurl Post.hs)
                        }
-  deriving (Eq,Show)
+  deriving (Show)
 
 -- | Show the protocol in use (currently either https or http)
 showProtocol :: Request -> String
@@ -154,6 +156,7 @@ parseURL tape = evalState parser (tape,Just initial)
                           , pathComps  = []
                           , qString    = fromList []
                           , reqPayload = B.empty
+                          , reqPayloadMult = []
                           }
 
 -- | Parse a query string.
@@ -175,6 +178,7 @@ parseQString tape = evalState parser (tape,Just initial)
                           , pathComps  = []
                           , qString    = fromList []
                           , reqPayload = B.empty
+                          , reqPayloadMult = []
                           }
 
 -- | Creates a FieldList type from a list.

--- a/src/main/haskell/Network/OAuth/Http/Request.hs
+++ b/src/main/haskell/Network/OAuth/Http/Request.hs
@@ -33,6 +33,10 @@ module Network.OAuth.Http.Request
        , FieldList()
        , Version(..)
        , Method(..)
+       , FormDataPart(..)
+       , Content(..)
+         -- * conversion of [FormDataPart] to curl's [HttpPost]
+       , convertMultipart
          -- * FieldList related functions
        , fromList
        , singleton
@@ -58,7 +62,8 @@ module Network.OAuth.Http.Request
        ) where
 
 import Control.Monad.State
-import Network.Curl.Post (HttpPost)
+import qualified Network.Curl.Post as Curl (HttpPost(..), Content(..))
+import qualified Network.Curl.Types as Curl (Long)
 import Network.OAuth.Http.PercentEncoding
 import Network.OAuth.Http.Util
 import Data.List (intercalate,isPrefixOf)
@@ -66,6 +71,7 @@ import Data.Monoid
 import Data.Char (toLower)
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Binary as Bi
+import Foreign.C.String (CString)
 
 -- | All known HTTP methods
 data Method =   GET
@@ -86,18 +92,55 @@ data Version =   Http10
 newtype FieldList = FieldList { unFieldList :: [(String,String)] }
   deriving (Eq,Ord)
 
-data Request = ReqHttp { version    :: Version      -- ^ Protocol version
-                       , ssl        :: Bool         -- ^ Wheter or not to use ssl
-                       , host       :: String       -- ^ The hostname to connect to
-                       , port       :: Int          -- ^ The port to connect to
-                       , method     :: Method       -- ^ The HTTP method of the request.
-                       , reqHeaders :: FieldList    -- ^ Request headers
-                       , pathComps  :: [String]     -- ^ The path split into components 
-                       , qString    :: FieldList    -- ^ The query string, usually set for GET requests
-                       , reqPayload :: B.ByteString -- ^ The message body (the first/only string part)
-                       , reqPayloadMult :: [HttpPost] -- ^ The message body (in HttpPost parts, see libcurl Post.hs)
+data Request = ReqHttp { version          :: Version        -- ^ Protocol version
+                       , ssl              :: Bool           -- ^ Wheter or not to use ssl
+                       , host             :: String         -- ^ The hostname to connect to
+                       , port             :: Int            -- ^ The port to connect to
+                       , method           :: Method         -- ^ The HTTP method of the request.
+                       , reqHeaders       :: FieldList      -- ^ Request headers
+                       , pathComps        :: [String]       -- ^ The path split into components 
+                       , qString          :: FieldList      -- ^ The query string, usually set for GET requests
+                       , reqPayload       :: B.ByteString   -- ^ The message body (the first/only string part)
+                       , multipartPayload :: [FormDataPart] -- ^ The message body (i.e., for multipart/form-data)
                        }
-  deriving (Show)
+  deriving (Eq,Show)
+
+-- one part of a multipart/form-data POST request
+data FormDataPart =
+   FormDataPart { postName     :: String
+                , contentType  :: Maybe String
+                , content      :: Content
+                , extraHeaders :: [String]
+                -- , extraEntries :: [FormDataPart]    -- commented out in Curl's Post.hs
+                , showName     :: Maybe String
+                }
+   deriving (Eq, Show)
+
+-- data for one part
+-- as either a String or a FilePath (for Curl to open and include)
+data Content = ContentFile FilePath
+             | ContentBuffer CString Curl.Long
+             | ContentString String
+   deriving (Eq, Show)
+
+-- convert one Part to Curl's HttpPost
+convertMultipart :: [FormDataPart] -> [Curl.HttpPost]
+convertMultipart parts =
+   map convertPart parts
+   where
+      convertPart :: FormDataPart -> Curl.HttpPost
+      convertPart part =
+         Curl.HttpPost { Curl.postName     = postName     part
+                       , Curl.contentType  = contentType  part
+                       , Curl.content      = convertCont (content part)
+                       , Curl.extraHeaders = extraHeaders part
+                       , Curl.showName     = showName     part
+                       }
+
+      convertCont :: Content -> Curl.Content
+      convertCont (ContentFile   z) = Curl.ContentFile   z
+      convertCont (ContentString y) = Curl.ContentString y
+      convertCont (ContentBuffer w x) = Curl.ContentBuffer w x
 
 -- | Show the protocol in use (currently either https or http)
 showProtocol :: Request -> String
@@ -156,7 +199,7 @@ parseURL tape = evalState parser (tape,Just initial)
                           , pathComps  = []
                           , qString    = fromList []
                           , reqPayload = B.empty
-                          , reqPayloadMult = []
+                          , multipartPayload = []
                           }
 
 -- | Parse a query string.
@@ -178,7 +221,7 @@ parseQString tape = evalState parser (tape,Just initial)
                           , pathComps  = []
                           , qString    = fromList []
                           , reqPayload = B.empty
-                          , reqPayloadMult = []
+                          , multipartPayload = []
                           }
 
 -- | Creates a FieldList type from a list.

--- a/src/test/haskell/Test/Network/OAuth/Http/CurlHttpClient.hs
+++ b/src/test/haskell/Test/Network/OAuth/Http/CurlHttpClient.hs
@@ -34,41 +34,41 @@ import Network.OAuth.Http.Request
 import Data.Maybe (fromJust)
 
 stest0 = T.TestCase $ do
-  Right response <- runClient CurlClient (fromJust $ parseURL "http://github.com/dsouza/hoauth/")
+  Right response <- runClient CurlClient (fromJust $ parseURL "https://github.com/dsouza/hoauth/")
   T.assertEqual
-    "Assert status code is set on response"
+    "curl0: Assert status code is set on response"
     (200)
     (status response)
 
   T.assertEqual
-    "Assert reason is set on response"
+    "curl0: Assert reason is set on response"
     ("HTTP/1.1 200 OK")
     (reason response)
 
   T.assertEqual
-    "Assert headers are set (content-type)"
+    "curl0: Assert headers are set (content-type)"
     (" text/html; charset=utf-8")
     (ifindWithDefault ("content-type","") (rspHeaders response))
 
   T.assertBool
-    "Assert header are set (content-length)"
+    "curl0: Assert header are set (content-length)"
     (not $ null $ ifindWithDefault ("content-length","") (rspHeaders response))
 
 stest1 = T.TestCase $ do
-  let req = fromJust $ parseURL "http://github.com/dsouza/hoauth/"
+  let req = fromJust $ parseURL "https://github.com/dsouza/hoauth/"
   Right response <- runClient CurlClient (req {method = HEAD})
   T.assertEqual
-    "Assert status code is set on response"
+    "curl1: Assert status code is set on response"
     (200)
     (status response)
 
   T.assertEqual
-    "Assert reason is set on response"
+    "curl1: Assert reason is set on response"
     ("HTTP/1.1 200 OK")
     (reason response)
 
   T.assertEqual
-    "Assert headers are set (content-type)"
+    "curl1: Assert headers are set (content-type)"
     (" text/html; charset=utf-8")
     (ifindWithDefault ("content-type","") (rspHeaders response))
 

--- a/src/test/haskell/Test/Network/OAuth/Http/Request.hs
+++ b/src/test/haskell/Test/Network/OAuth/Http/Request.hs
@@ -162,12 +162,12 @@ ftest10 = T.TestCase $ do
   T.assertEqual
     "Test showURL do the right thing"
     ("https://foo.bar:9999/%20foo%23/bar?a=%C3%A1&b=10&c=%22test%22")
-    (showURL $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty)
+    (showURL $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty [])
 
 ftest11 = T.TestCase $ do
   T.assertEqual
     "Test parseURL do the right thing"
-    (Just $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty)
+    (Just $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty [])
     (parseURL "https://foo.bar:9999/%20foo%23/bar?a=%C3%A1&b=10&c=%22test%22")
 
 ftest12 = T.TestCase $ do
@@ -179,8 +179,8 @@ ftest12 = T.TestCase $ do
 
   T.assertEqual
     "Test parseURL . showURL = id"
-    (ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty)
-    (fromJust . parseURL . showURL $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty)
+    (ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty [])
+    (fromJust . parseURL . showURL $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty [])
 
 ftest13 = T.TestCase $ do
   T.assertEqual

--- a/src/test/haskell/test_hoauth.hs
+++ b/src/test/haskell/test_hoauth.hs
@@ -30,7 +30,6 @@ import Test.Network.OAuth.Http.Request as R
 import Test.Network.OAuth.Http.PercentEncoding as P
 import Test.Network.OAuth.Http.Util as U
 import Test.Network.OAuth.Http.CurlHttpClient as W
-import System 
 
 all_tests = let fast = [C.fast_tests,R.fast_tests,P.fast_tests,U.fast_tests,W.fast_tests]
                 slow = [C.slow_tests,R.slow_tests,P.slow_tests,U.slow_tests,W.slow_tests]

--- a/src/test/haskell/test_hoauth.hs
+++ b/src/test/haskell/test_hoauth.hs
@@ -30,6 +30,7 @@ import Test.Network.OAuth.Http.Request as R
 import Test.Network.OAuth.Http.PercentEncoding as P
 import Test.Network.OAuth.Http.Util as U
 import Test.Network.OAuth.Http.CurlHttpClient as W
+import System.Exit
 
 all_tests = let fast = [C.fast_tests,R.fast_tests,P.fast_tests,U.fast_tests,W.fast_tests]
                 slow = [C.slow_tests,R.slow_tests,P.slow_tests,U.slow_tests,W.slow_tests]


### PR DESCRIPTION
This adds the ability to make multipart/form-data POST requests, so that we can do things like upload images to Twitter.  

I wanted to get this out while it is on my mind.  There are a couple of things I'll revisit soon.

(1) Currently libcurl `HttpPost` does not derive Eq, so I've removed that from `Request`, for the moment.  There's a possibility that removing Request's Eq instance breaks something in the test code, which I need to look at, or elsewhere.  (It should be trivial for the libcurl maintainers to add Eq to more things, so this is a temporary problem.)

(2) I may also want to modify this to avoid having to import libcurl elsewhere to create requests with multipart payloads (using libcurl's HttpPost and Content types).  Are there plans to replace libcurl with another library, for example?
