### PR TITLE
Add crypto-pubkey-types dependency with newer RSA

### DIFF
--- a/hoauth.cabal
+++ b/hoauth.cabal
@@ -19,6 +19,7 @@ description: This library implements all PLAINTEXT, HMAC-SHA1 and RSA-SHA1
 library
   build-depends: base<5
                , bytestring>=0.9.1.5
+               , crypto-pubkey-types>=0.1.1
                , binary>=0.5.0.2
                , SHA>=1.4.1.1
                , dataenc>=0.13.0.2
@@ -28,7 +29,7 @@ library
                , random>=1.0.0.2
                , curl>=1.3.5
                , mtl>=1.1.0.2
-               , RSA>=1.0.5 && <1.2
+               , RSA>=1.2.0.1
                , entropy>=0.2.1
   exposed-modules:  Network.OAuth.Http.Request
                  , Network.OAuth.Http.Response

--- a/src/main/haskell/Network/OAuth/Consumer.hs
+++ b/src/main/haskell/Network/OAuth/Consumer.hs
@@ -99,7 +99,8 @@ import qualified Data.Digest.Pure.SHA as S
 import qualified Codec.Binary.Base64 as B64
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as B
-import qualified Codec.Crypto.RSA as R
+import qualified Codec.Crypto.RSA        as R
+import qualified Crypto.Types.PubKey.RSA as R
 
 -- | A request that is ready to be performed, i.e., that contains authorization headers.
 newtype OAuthRequest = OAuthRequest { unpackRq :: Request }

--- a/src/main/haskell/Network/OAuth/Consumer.hs
+++ b/src/main/haskell/Network/OAuth/Consumer.hs
@@ -103,7 +103,7 @@ import qualified Codec.Crypto.RSA as R
 
 -- | A request that is ready to be performed, i.e., that contains authorization headers.
 newtype OAuthRequest = OAuthRequest { unpackRq :: Request }
-                     deriving (Show,Eq)
+                     deriving (Show)
 
 -- | Random string that is unique amongst requests. Refer to <http://oauth.net/core/1.0/#nonce> for more information.
 newtype Nonce = Nonce { unNonce :: String }
@@ -203,9 +203,13 @@ signature m token req = case m
                                             ]
 
         params = if (ifindWithDefault ("content-type","") (reqHeaders req) == "application/x-www-form-urlencoded")
+
+                 -- e.g., in the case of most Twitter API calls
                  then (qString req) `unionAll` (parseQString . map (chr.fromIntegral) 
                                                              . B.unpack 
                                                              . reqPayload $ req)
+
+                 -- e.g., in the case of a "multipart/form-data" image upload, however, the payload isn't signed
                  else qString req
 
 -- | Returns true if the token is able to perform 2-legged oauth requests.

--- a/src/main/haskell/Network/OAuth/Http/CurlHttpClient.hs
+++ b/src/main/haskell/Network/OAuth/Http/CurlHttpClient.hs
@@ -61,18 +61,31 @@ instance HttpClient CurlClient where
           curlMethod = case (method req)
                        of GET   -> [ CurlHttpGet True ]
                           HEAD  -> [ CurlNoBody True,CurlCustomRequest "HEAD" ]
-                          other -> if (B.null.reqPayload $ req)
+                          other -> if ((B.null . reqPayload $ req) && 0 == length (reqPayloadMult req))
                                    then [ CurlHttpGet True,CurlCustomRequest (show other) ]
                                    else [ CurlPost True,CurlCustomRequest (show other) ]
                                         
-          curlPostData = if (B.null.reqPayload $ req)
-                         then []
-                         else [ CurlPostFields [map (chr.fromIntegral).B.unpack.reqPayload $ req] ]
-                              
+          curlPostData =
+             if B.null . reqPayload $ req
+             then
+                case reqPayloadMult req
+                of []    -> []                   -- i.e., no payload at all
+
+                   parts -> [CurlHttpPost parts] -- i.e., "multipart/form-data"
+                                                 -- content with a boundary and MIME stuff
+                                                 -- see libcurl for HttpPost, Content
+             else
+                case reqPayloadMult req
+                of []    -> let tostr = map (chr.fromIntegral).B.unpack
+                                field = reqPayload req
+                            in [CurlPostFields [tostr field]] -- i.e., "application/x-www-form-urlencoded"
+                                                              -- strings with field sep '&'
+                                                              -- although we're only giving libcurl a single field
+
+                   parts -> error "with both CurlPostFields and CurlHttpPost, I'm not sure what libcurl would do..."
+
           curlHeaders = let headers = (map (\(k,v) -> k++": "++v).toList.reqHeaders $ req)
-                        in [ CurlHttpHeaders $ ("Content-Length: " ++ (show.B.length.reqPayload $ req))
-                                               : headers
-                           ]
+                        in [CurlHttpHeaders headers]
 
           opts = [ CurlURL (showURL req)
                  , CurlHttpVersion httpVersion

--- a/src/main/haskell/Network/OAuth/Http/Request.hs
+++ b/src/main/haskell/Network/OAuth/Http/Request.hs
@@ -58,6 +58,7 @@ module Network.OAuth.Http.Request
        ) where
 
 import Control.Monad.State
+import Network.Curl.Post (HttpPost)
 import Network.OAuth.Http.PercentEncoding
 import Network.OAuth.Http.Util
 import Data.List (intercalate,isPrefixOf)
@@ -93,9 +94,10 @@ data Request = ReqHttp { version    :: Version      -- ^ Protocol version
                        , reqHeaders :: FieldList    -- ^ Request headers
                        , pathComps  :: [String]     -- ^ The path split into components 
                        , qString    :: FieldList    -- ^ The query string, usually set for GET requests
-                       , reqPayload :: B.ByteString -- ^ The message body
+                       , reqPayload :: B.ByteString -- ^ The message body (the first/only string part)
+                       , reqPayloadMult :: [HttpPost] -- ^ The message body (in HttpPost parts, see libcurl Post.hs)
                        }
-  deriving (Eq,Show)
+  deriving (Show)
 
 -- | Show the protocol in use (currently either https or http)
 showProtocol :: Request -> String
@@ -154,6 +156,7 @@ parseURL tape = evalState parser (tape,Just initial)
                           , pathComps  = []
                           , qString    = fromList []
                           , reqPayload = B.empty
+                          , reqPayloadMult = []
                           }
 
 -- | Parse a query string.
@@ -175,6 +178,7 @@ parseQString tape = evalState parser (tape,Just initial)
                           , pathComps  = []
                           , qString    = fromList []
                           , reqPayload = B.empty
+                          , reqPayloadMult = []
                           }
 
 -- | Creates a FieldList type from a list.

--- a/src/main/haskell/Network/OAuth/Http/Request.hs
+++ b/src/main/haskell/Network/OAuth/Http/Request.hs
@@ -33,6 +33,10 @@ module Network.OAuth.Http.Request
        , FieldList()
        , Version(..)
        , Method(..)
+       , FormDataPart(..)
+       , Content(..)
+         -- * conversion of [FormDataPart] to curl's [HttpPost]
+       , convertMultipart
          -- * FieldList related functions
        , fromList
        , singleton
@@ -58,7 +62,8 @@ module Network.OAuth.Http.Request
        ) where
 
 import Control.Monad.State
-import Network.Curl.Post (HttpPost)
+import qualified Network.Curl.Post as Curl (HttpPost(..), Content(..))
+import qualified Network.Curl.Types as Curl (Long)
 import Network.OAuth.Http.PercentEncoding
 import Network.OAuth.Http.Util
 import Data.List (intercalate,isPrefixOf)
@@ -66,6 +71,7 @@ import Data.Monoid
 import Data.Char (toLower)
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Binary as Bi
+import Foreign.C.String (CString)
 
 -- | All known HTTP methods
 data Method =   GET
@@ -86,18 +92,55 @@ data Version =   Http10
 newtype FieldList = FieldList { unFieldList :: [(String,String)] }
   deriving (Eq,Ord)
 
-data Request = ReqHttp { version    :: Version      -- ^ Protocol version
-                       , ssl        :: Bool         -- ^ Wheter or not to use ssl
-                       , host       :: String       -- ^ The hostname to connect to
-                       , port       :: Int          -- ^ The port to connect to
-                       , method     :: Method       -- ^ The HTTP method of the request.
-                       , reqHeaders :: FieldList    -- ^ Request headers
-                       , pathComps  :: [String]     -- ^ The path split into components 
-                       , qString    :: FieldList    -- ^ The query string, usually set for GET requests
-                       , reqPayload :: B.ByteString -- ^ The message body (the first/only string part)
-                       , reqPayloadMult :: [HttpPost] -- ^ The message body (in HttpPost parts, see libcurl Post.hs)
+data Request = ReqHttp { version          :: Version        -- ^ Protocol version
+                       , ssl              :: Bool           -- ^ Wheter or not to use ssl
+                       , host             :: String         -- ^ The hostname to connect to
+                       , port             :: Int            -- ^ The port to connect to
+                       , method           :: Method         -- ^ The HTTP method of the request.
+                       , reqHeaders       :: FieldList      -- ^ Request headers
+                       , pathComps        :: [String]       -- ^ The path split into components 
+                       , qString          :: FieldList      -- ^ The query string, usually set for GET requests
+                       , reqPayload       :: B.ByteString   -- ^ The message body (the first/only string part)
+                       , multipartPayload :: [FormDataPart] -- ^ The message body (i.e., for multipart/form-data)
                        }
-  deriving (Show)
+  deriving (Eq,Show)
+
+-- one part of a multipart/form-data POST request
+data FormDataPart =
+   FormDataPart { postName     :: String
+                , contentType  :: Maybe String
+                , content      :: Content
+                , extraHeaders :: [String]
+                -- , extraEntries :: [FormDataPart]    -- commented out in Curl's Post.hs
+                , showName     :: Maybe String
+                }
+   deriving (Eq, Show)
+
+-- data for one part
+-- as either a String or a FilePath (for Curl to open and include)
+data Content = ContentFile FilePath
+             | ContentBuffer CString Curl.Long
+             | ContentString String
+   deriving (Eq, Show)
+
+-- convert one Part to Curl's HttpPost
+convertMultipart :: [FormDataPart] -> [Curl.HttpPost]
+convertMultipart parts =
+   map convertPart parts
+   where
+      convertPart :: FormDataPart -> Curl.HttpPost
+      convertPart part =
+         Curl.HttpPost { Curl.postName     = postName     part
+                       , Curl.contentType  = contentType  part
+                       , Curl.content      = convertCont (content part)
+                       , Curl.extraHeaders = extraHeaders part
+                       , Curl.showName     = showName     part
+                       }
+
+      convertCont :: Content -> Curl.Content
+      convertCont (ContentFile   z) = Curl.ContentFile   z
+      convertCont (ContentString y) = Curl.ContentString y
+      convertCont (ContentBuffer w x) = Curl.ContentBuffer w x
 
 -- | Show the protocol in use (currently either https or http)
 showProtocol :: Request -> String
@@ -156,7 +199,7 @@ parseURL tape = evalState parser (tape,Just initial)
                           , pathComps  = []
                           , qString    = fromList []
                           , reqPayload = B.empty
-                          , reqPayloadMult = []
+                          , multipartPayload = []
                           }
 
 -- | Parse a query string.
@@ -178,7 +221,7 @@ parseQString tape = evalState parser (tape,Just initial)
                           , pathComps  = []
                           , qString    = fromList []
                           , reqPayload = B.empty
-                          , reqPayloadMult = []
+                          , multipartPayload = []
                           }
 
 -- | Creates a FieldList type from a list.

--- a/src/test/haskell/Test/Network/OAuth/Consumer.hs
+++ b/src/test/haskell/Test/Network/OAuth/Consumer.hs
@@ -39,7 +39,8 @@ import Network.OAuth.Http.CurlHttpClient
 import Network.OAuth.Http.PercentEncoding
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Binary as Bi
-import qualified Codec.Crypto.RSA as R
+import qualified Codec.Crypto.RSA        as R
+import qualified Crypto.Types.PubKey.RSA as R
 
 ftest0 = T.TestCase $ do
   let token     = fromApplication $ Application "dpf43f3p2l4k3l03" "kd94hf93k423kf44" (URL "http://printer.example.com/request_token_ready")
@@ -275,7 +276,7 @@ ftest12 = T.TestCase $ do
   let modulus  = 0x00ce3fe6af65b85d7744a287268f0aea4fd783005b6306f353e9e49a9583f7d4ebc7870a65fc30ccdd5ce7a84b8d5a9356f06ae3d00599e5c8bda3b543f4331ccf04fd931e108d75e4abea9c120f46fe735138c31344e4b74a1788edf161d9c2ac6f8cc993927fcab4ef956b7150278daed0d2d630413a5ad56658026a3bcb3ced
       expoent  = 0x17e54d6bdae42e68081ab07fe628c496f58826fd6f8eb9986a4be321198618342d0cd746939e6fcde1dab123f7bf9bbc81e4507aa47b7d24f1dbcabf91c66e3ad490605bcc36a8568bce27dc9d1584dc3e443499f819dc0a9d2b0233f5ae6d8ab8435121c811ffc7a5491718479d246d52f27172e5903f66814431186ec607e1
       numbytes = 128
-      key      = R.PrivateKey numbytes modulus expoent
+      key      = R.PrivateKey numbytes modulus expoent 0 0 0 0 0 -- optional fields are zero, per documentation
       Just req = parseURL "http://foo.bar:8080/foobar?foo=bar&bar=foo"
       app      = Application "<<dummy>>" "<<dummy>>" OOB
   T.assertEqual
@@ -287,7 +288,7 @@ ftest13 = T.TestCase $ do
   let modulus   = 0x00ce3fe6af65b85d7744a287268f0aea4fd783005b6306f353e9e49a9583f7d4ebc7870a65fc30ccdd5ce7a84b8d5a9356f06ae3d00599e5c8bda3b543f4331ccf04fd931e108d75e4abea9c120f46fe735138c31344e4b74a1788edf161d9c2ac6f8cc993927fcab4ef956b7150278daed0d2d630413a5ad56658026a3bcb3ced
       expoent   = 0x17e54d6bdae42e68081ab07fe628c496f58826fd6f8eb9986a4be321198618342d0cd746939e6fcde1dab123f7bf9bbc81e4507aa47b7d24f1dbcabf91c66e3ad490605bcc36a8568bce27dc9d1584dc3e443499f819dc0a9d2b0233f5ae6d8ab8435121c811ffc7a5491718479d246d52f27172e5903f66814431186ec607e1
       numbytes  = 128
-      key       = R.PrivateKey numbytes modulus expoent
+      key       = R.PrivateKey numbytes modulus expoent 0 0 0 0 0
       Just req0 = parseURL "http://foo.bar:80/foobar?foo=bar&bar=foo"
       Just req1 = parseURL "https://foo.bar:443/foobar?foo=bar&bar=foo"
       app       = Application "<<dummy>>" "<<dummy>>" OOB

--- a/src/test/haskell/Test/Network/OAuth/Http/CurlHttpClient.hs
+++ b/src/test/haskell/Test/Network/OAuth/Http/CurlHttpClient.hs
@@ -34,41 +34,41 @@ import Network.OAuth.Http.Request
 import Data.Maybe (fromJust)
 
 stest0 = T.TestCase $ do
-  Right response <- runClient CurlClient (fromJust $ parseURL "http://github.com/dsouza/hoauth/")
+  Right response <- runClient CurlClient (fromJust $ parseURL "https://github.com/dsouza/hoauth/")
   T.assertEqual
-    "Assert status code is set on response"
+    "curl0: Assert status code is set on response"
     (200)
     (status response)
 
   T.assertEqual
-    "Assert reason is set on response"
+    "curl0: Assert reason is set on response"
     ("HTTP/1.1 200 OK")
     (reason response)
 
   T.assertEqual
-    "Assert headers are set (content-type)"
+    "curl0: Assert headers are set (content-type)"
     (" text/html; charset=utf-8")
     (ifindWithDefault ("content-type","") (rspHeaders response))
 
   T.assertBool
-    "Assert header are set (content-length)"
+    "curl0: Assert header are set (content-length)"
     (not $ null $ ifindWithDefault ("content-length","") (rspHeaders response))
 
 stest1 = T.TestCase $ do
-  let req = fromJust $ parseURL "http://github.com/dsouza/hoauth/"
+  let req = fromJust $ parseURL "https://github.com/dsouza/hoauth/"
   Right response <- runClient CurlClient (req {method = HEAD})
   T.assertEqual
-    "Assert status code is set on response"
+    "curl1: Assert status code is set on response"
     (200)
     (status response)
 
   T.assertEqual
-    "Assert reason is set on response"
+    "curl1: Assert reason is set on response"
     ("HTTP/1.1 200 OK")
     (reason response)
 
   T.assertEqual
-    "Assert headers are set (content-type)"
+    "curl1: Assert headers are set (content-type)"
     (" text/html; charset=utf-8")
     (ifindWithDefault ("content-type","") (rspHeaders response))
 

--- a/src/test/haskell/Test/Network/OAuth/Http/Request.hs
+++ b/src/test/haskell/Test/Network/OAuth/Http/Request.hs
@@ -162,12 +162,12 @@ ftest10 = T.TestCase $ do
   T.assertEqual
     "Test showURL do the right thing"
     ("https://foo.bar:9999/%20foo%23/bar?a=%C3%A1&b=10&c=%22test%22")
-    (showURL $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty)
+    (showURL $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty [])
 
 ftest11 = T.TestCase $ do
   T.assertEqual
     "Test parseURL do the right thing"
-    (Just $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty)
+    (Just $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty [])
     (parseURL "https://foo.bar:9999/%20foo%23/bar?a=%C3%A1&b=10&c=%22test%22")
 
 ftest12 = T.TestCase $ do
@@ -179,8 +179,8 @@ ftest12 = T.TestCase $ do
 
   T.assertEqual
     "Test parseURL . showURL = id"
-    (ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty)
-    (fromJust . parseURL . showURL $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty)
+    (ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty [])
+    (fromJust . parseURL . showURL $ ReqHttp Http11 True "foo.bar" 9999 GET empty [""," foo#","bar"] (fromList [("a","á"),("b","10"),("c","\"test\"")]) B.empty [])
 
 ftest13 = T.TestCase $ do
   T.assertEqual

--- a/src/test/haskell/test_hoauth.hs
+++ b/src/test/haskell/test_hoauth.hs
@@ -30,7 +30,6 @@ import Test.Network.OAuth.Http.Request as R
 import Test.Network.OAuth.Http.PercentEncoding as P
 import Test.Network.OAuth.Http.Util as U
 import Test.Network.OAuth.Http.CurlHttpClient as W
-import System 
 
 all_tests = let fast = [C.fast_tests,R.fast_tests,P.fast_tests,U.fast_tests,W.fast_tests]
                 slow = [C.slow_tests,R.slow_tests,P.slow_tests,U.slow_tests,W.slow_tests]

--- a/src/test/haskell/test_hoauth.hs
+++ b/src/test/haskell/test_hoauth.hs
@@ -30,6 +30,7 @@ import Test.Network.OAuth.Http.Request as R
 import Test.Network.OAuth.Http.PercentEncoding as P
 import Test.Network.OAuth.Http.Util as U
 import Test.Network.OAuth.Http.CurlHttpClient as W
+import System.Exit
 
 all_tests = let fast = [C.fast_tests,R.fast_tests,P.fast_tests,U.fast_tests,W.fast_tests]
                 slow = [C.slow_tests,R.slow_tests,P.slow_tests,U.slow_tests,W.slow_tests]


### PR DESCRIPTION
(This commit c033b7c7 is really a tentative reaction to 3404f64f2d where @mwotton limited RSA to < 1.2.  Other commits on this branch are all part of #6.)

Within the RSA package between version 1.2.0.0 and 1.2.0.1,
some of the types were removed and used from crypto-pubkey-types.

This adds and bumps the dependencies to:
   RSA >= 1.2.0.1
   crypto-pubkey-types >= 0.1.1
