### PR TITLE
Use root certificates

### DIFF
--- a/src/main/haskell/Network/OAuth/Http/CurlHttpClient.hs
+++ b/src/main/haskell/Network/OAuth/Http/CurlHttpClient.hs
@@ -77,8 +77,8 @@ instance HttpClient CurlClient where
           opts = [ CurlURL (showURL req)
                  , CurlHttpVersion httpVersion
                  , CurlHeader False
-                 , CurlSSLVerifyHost 1
-                 , CurlSSLVerifyPeer False
+                 , CurlSSLVerifyHost 2
+                 , CurlSSLVerifyPeer True
                  , CurlTimeout 30
                  ] ++ curlHeaders
                    ++ curlMethod 


### PR DESCRIPTION
This commit causes **libcurl** to actually verify server certificates using
system-level root CA certificates.  Otherwise, software which doesn't
override the default settings with `OptionsCurlClient` (to enable
`CurlSSLVerifyHost` and `CurlSSLVerifyPeer`) will remain vulnerable
to man-in-the-middle attacks.
