### PR TITLE
Suggested fix for response bodies with UTF-8

### DIFF
--- a/src/main/haskell/Network/OAuth/Http/CurlHttpClient.hs
+++ b/src/main/haskell/Network/OAuth/Http/CurlHttpClient.hs
@@ -38,6 +38,7 @@ import Network.OAuth.Http.Response
 import Control.Monad.Trans
 import Data.Char (chr,ord)
 import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString.Lazy.UTF8 as U
 
 data CurlClient = CurlClient | OptionsCurlClient [CurlOption]
 
@@ -102,4 +103,7 @@ instance HttpClient CurlClient where
                                of CurlClient -> []
                                   OptionsCurlClient o -> o
           
-          fromResponse rsp = RspHttp (respStatus rsp) (respStatusLine rsp) (fromList.respHeaders $ rsp) (B.pack.map (fromIntegral.ord).respBody $ rsp)
+          packedBody rsp = U.fromString . respBody $ rsp
+
+          fromResponse rsp = RspHttp (respStatus rsp) (respStatusLine rsp) (fromList.respHeaders $ rsp) (packedBody rsp)
+


### PR DESCRIPTION
This pull request incorporates the fix for handling UTF-8 in responses from @rudyl313, https://github.com/dgvncsz0f/hoauth/issues/13.

This got me looking for similar patterns and testing UTF-8, and thinking about how many little stumbling blocks there are between this and thorough UTF-8 support everywhere.  That will take some time, but this seems like a simple patch now...
