### PR TITLE
Updated SHA1 hash reference

### DIFF
--- a/src/main/haskell/Network/OAuth/Consumer.hs
+++ b/src/main/haskell/Network/OAuth/Consumer.hs
@@ -185,7 +185,7 @@ signature :: SigMethod -> Token -> Request -> String
 signature m token req = case m
                         of PLAINTEXT -> key
                            HMACSHA1  -> b64encode $ S.bytestringDigest (S.hmacSha1 (bsencode key) (bsencode text))
-                           RSASHA1 k -> b64encode $ R.rsassa_pkcs1_v1_5_sign R.ha_SHA1 k (bsencode text)
+                           RSASHA1 k -> b64encode $ R.rsassa_pkcs1_v1_5_sign R.hashSHA1 k (bsencode text)
 
   where bsencode  = B.pack . map (fromIntegral.ord)
         b64encode = B64.encode . B.unpack


### PR DESCRIPTION
crypto-pubkey-types must have changed their API as this no longer compiles. Fixed reference to hashSHA1.
